### PR TITLE
Fix parsing (x,y) byte deltas in stf file.

### DIFF
--- a/stf.py
+++ b/stf.py
@@ -260,6 +260,9 @@ class STFParser(object):
                         else:
                             deltax = br.get_bits(8)
                             deltay = br.get_bits(8)
+                            # sign-extend
+                            if deltax & 0x80: deltax = deltax | -0x100
+                            if deltay & 0x80: deltay = deltay | -0x100
                     else:
                         deltax = self.get_deltax()
                         deltay = self.get_deltay()


### PR DESCRIPTION
Within a stroke, each coordinate can be encoded using an absolute position, an 8-bit delta, or a prefix-free coded delta. Fix the 8-bit deltas, which are actually signed integers.

[Patch to libsmartpen](https://github.com/srwalter/libsmartpen/pull/4) also sent.
